### PR TITLE
The correct config keys were not being passed to MetzWeb\Instagram, resu...

### DIFF
--- a/src/Vinkla/Instagram/InstagramServiceProvider.php
+++ b/src/Vinkla/Instagram/InstagramServiceProvider.php
@@ -29,11 +29,11 @@ class InstagramServiceProvider extends ServiceProvider {
 				return new Instagram($app['config']['instagram::client_id']);
 			}
 
-			return new Instagram([
-				$app['config']['instagram::client_id'],
-				$app['config']['instagram::client_secret'],
-				$app['config']['instagram::callback_url']
-			]);
+			return new Instagram(array(
+				'apiKey' => $app['config']['instagram::client_id'],
+				'apiSecret' => $app['config']['instagram::client_secret'],
+				'apiCallback' => $app['config']['instagram::callback_url']
+			));
 		});
 	}
 


### PR DESCRIPTION
When using the facade, I get the following php error:

exception 'ErrorException' with message 'Undefined index: apiKey' in /var/www/dockvine/dockvine_api/vendor/cosenary/instagram/src/Instagram.php:92

This is because the MetzWeb\Instagram Instagram class constructor is expecting the following array keys in the  $config:

```php
$this->setApiKey($config['apiKey']);
$this->setApiSecret($config['apiSecret']);
$this->setApiCallback($config['apiCallback']);
```

However, those keys were not being passed correctly from the InstagramServiceProvider. Fix in this PR.
