### PR TITLE
Catch empty body error

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -119,6 +119,10 @@ class Instagram
             throw new InstagramException($body->meta->error_message);
         }
 
+        if ($response->getStatusCode() !== 200) {
+            throw new InstagramException($response->getReasonPhrase());
+        }
+
         return $body;
     }
 }

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -66,4 +66,24 @@ class InstagramTest extends TestCase
 
         (new Instagram('imspeechlessihavenospeech'))->media();
     }
+
+    public function testHttpError()
+    {
+        $this->expectException(InstagramException::class);
+        $this->expectExceptionMessage('No server is available for the request');
+
+        $response = new Response(503,
+            [],
+            null,
+            null,
+            'No server is available for the request');
+
+        $client = new Client();
+        $client->addResponse($response);
+
+        $instagram = new Instagram('jerryseinfeld', $client);
+        $user = $instagram->self();
+
+
+    }
 }

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -72,11 +72,7 @@ class InstagramTest extends TestCase
         $this->expectException(InstagramException::class);
         $this->expectExceptionMessage('No server is available for the request');
 
-        $response = new Response(503,
-            [],
-            null,
-            null,
-            'No server is available for the request');
+        $response = new Response(503, [], null, null, 'No server is available for the request');
 
         $client = new Client();
         $client->addResponse($response);

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -83,7 +83,5 @@ class InstagramTest extends TestCase
 
         $instagram = new Instagram('jerryseinfeld', $client);
         $user = $instagram->self();
-
-
     }
 }


### PR DESCRIPTION
Today Instagram was down for an hour and our website received a type error
`Return value of Vinkla\Instagram\Instagram::get() must be an object, null returned`
I think this will also fix issue #89 and #75 
I added a test that mimics the response I got from Instagram.
```
Response {#499 ▼
  -reasonPhrase: "No server is available for the request"
  -statusCode: 503
```