### PR TITLE
Update to latest version of php-http/guzzle6-adapter (fix conflict)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php-http/message-factory": "^1.0"
     },
     "require-dev": {
-        "php-http/guzzle6-adapter": "^1.1",
+        "php-http/guzzle6-adapter": "^2.0",
         "php-http/message": "^1.7",
         "php-http/mock-client": "^1.1",
         "phpunit/phpunit": "^7.4"


### PR DESCRIPTION
Hey!

The current composer restrictions / version conflict when installing. 

`php-http/guzzle6-adapter` version `^1.1` has [this dependency](https://github.com/php-http/guzzle6-adapter/blob/v1.1.1/composer.json#L19)

```
"php-http/httplug": "^1.0",
``` 

However, your composer package requires...
```
"php-http/httplug": "^1.1 || ^2.0",
```

Causing a conflict on installation. About to end through another PR, hence stumbling across this.