### PR TITLE
Allow additional query parameters for media method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ To fetch the user's recent media items you may use the `media()` method.
 $instagram->media();
 ```
 
+You can pass [additional query parameters](https://www.instagram.com/developer/endpoints/users/#get_users_media_recent_self) to the `media()` method if needed.
+
+```php
+$instagram->media(['count' => 5]);
+```
+
 To fetch the user information data you may use the `self()` method.
 
 ```php

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -72,11 +72,13 @@ class Instagram
     /**
      * Fetch recent user media items.
      *
+     * @param array $parameters
+     *
      * @return array
      */
-    public function media(): array
+    public function media(array $parameters = []): array
     {
-        $response = $this->get('users/self/media/recent');
+        $response = $this->get('users/self/media/recent', $parameters);
 
         return $response->data;
     }
@@ -97,14 +99,17 @@ class Instagram
      * Send a get request.
      *
      * @param string $path
+     * @param array $parameters
      *
      * @throws \Vinkla\Instagram\InstagramException
      *
      * @return object
      */
-    protected function get(string $path): object
+    protected function get(string $path, array $parameters = []): object
     {
-        $url = sprintf('https://api.instagram.com/v1/%s?access_token=%s', $path, $this->accessToken);
+        $parameters = $this->prepareParameters($parameters);
+
+        $url = sprintf('https://api.instagram.com/v1/%s?%s', $path, http_build_query($parameters));
 
         $request = $this->requestFactory->createRequest('GET', $url);
         $response = $this->httpClient->sendRequest($request);
@@ -124,5 +129,19 @@ class Instagram
         }
 
         return $body;
+    }
+
+    /**
+     * Add access token and escape parameters.
+     *
+     * @param array $parameters
+     *
+     * @return array
+     */
+    protected function prepareParameters(array $parameters)
+    {
+        return array_merge([
+            'access_token' => $this->accessToken,
+        ], $parameters);
     }
 }

--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -59,6 +59,31 @@ class InstagramTest extends TestCase
         $this->assertInternalType('object', $user);
     }
 
+    public function testCanAppendParametersToMedia()
+    {
+        $response = new Response(200, [], json_encode([
+            'data' => [],
+            'meta' => [],
+        ]));
+
+        $client = new Client();
+        $client->addResponse($response);
+
+        $instagram = new Instagram('jerryseinfeld', $client);
+        $instagram->media([
+            'count' => 22,
+            'min_id' => 'expected minimum id',
+            'max_id' => 'expected maximum id',
+        ]);
+
+        $request = $client->getLastRequest();
+
+        $this->assertSame(
+            'access_token=jerryseinfeld&count=22&min_id=expected+minimum+id&max_id=expected+maximum+id',
+            $request->getUri()->getQuery()
+        );
+    }
+
     public function testError()
     {
         $this->expectException(InstagramException::class);


### PR DESCRIPTION
The recent media endpoint ([docs](https://www.instagram.com/developer/endpoints/users/#get_users_media_recent_self)) allow for a couple of parameters.

This PR introduces the ability to send these parameters with the request.

```php
// get only 3 of the most recent media...

$instagram->media(['count' => 3]);
```